### PR TITLE
Login directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following role variables are relevant:
   * Values can be plain strings, or dictionaries containing `name`, `group` and `mode` key/value pairs. (an ansible bug force us to accept only 3 digits for `mode`, not 4)
 * `sftp_allow_passwords`: Whether or not to allow password authentication for SFTP users. Defaults to False. NOTE: if global SSH configuration does not allow to use passwords, setting this to True will not work (see and adapt `PasswordAuthentication` from SSH configuration).
 * `sftp_enable_logging`: Enable logging. Auth logs will be written to `/var/log/sftp/auth.log`, and SFTP activity logs will be written to `/var/log/sftp/verbose.log`. Defaults to False.
+* `sftp_enable_login_directory`: Enable user to log in to a specific subdirectory from its home. When True, can specify a `login_directory` in some or all `sftp_users`. Defaults to False.
 * `sftp_groups`: A list of groups, in map form, containing the following elements:
   * `name`: The Unix name of the group that requires SFTP access.
   * `gid`: The group identifier.
@@ -36,6 +37,7 @@ The following role variables are relevant:
   * `authorized`: An optional list of files placed in `files/` which contain valid public keys for the SFTP user.
   * `sftp_directories`: A list of directories that need to be individually created for an SFTP user. Defaults to a blank list (i.e. "[]").
   * `append`: Boolean to add `sftp_group_name` to the user groups (if any) instead of setting it (default to `False`).
+  * `login_directory`: An optional path for the user to connect to at login when `sftp_enable_login_directory` is set to True.
 * `sftp_nologin_shell`: The "nologin" user shell. (defaults to /sbin/nologin.)
 * `sftp_host_keys`: Dictionnary of ssh host keys. Useful when you want to use custom ssh host keys. For example when you need to share the same ssh host keys on several hosts.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ sftp_allow_passwords: False
 sftp_enable_logging: False
 sftp_nologin_shell: /sbin/nologin
 sftp_chroot_group: "{{ sftp_group_name }}"
+sftp_enable_login_directory: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,18 @@
     state: present
   notify: SFTP-Server | Restart sshd
 
-- name: SFTP-Server | Add sshd_config block
+- name: SFTP-Server | Add 'Match User' sshd_config block
+  blockinfile:
+    dest: /etc/ssh/sshd_config
+    marker: '# {mark} SFTP-Server {{ item.name }} block'
+    block: |
+      Match User {{ item.name }}
+          ForceCommand internal-sftp {{ sftp_enable_logging | ternary('-l VERBOSE', '') }} {% if item.login_directory is defined %}-d {{ item.login_directory }}{% endif %}{{''}}
+  with_items: "{{ sftp_users }}"
+  when: sftp_enable_login_directory
+  notify: SFTP-Server | Restart sshd
+
+- name: SFTP-Server | Add 'Match Group' sshd_config block
   blockinfile:
     dest: /etc/ssh/sshd_config
     marker: '# {mark} SFTP-Server {{ item.name }} block'
@@ -26,12 +37,10 @@
           ChrootDirectory %h
           AllowTCPForwarding no
           X11Forwarding no
-          ForceCommand internal-sftp {{ sftp_enable_logging | ternary('-l VERBOSE', '') }} {% if item.readonly is defined and item.readonly %}-R{% endif %}
-
+          ForceCommand internal-sftp {{ sftp_enable_logging | ternary('-l VERBOSE', '') }} {% if item.readonly is defined and item.readonly %}-R{% endif %}{{''}}
           PasswordAuthentication {{ sftp_allow_passwords | ternary('yes', 'no') }}
   notify: SFTP-Server | Restart sshd
-  with_items:
-    - "{{ sftp_groups }}"
+  with_items: "{{ sftp_groups }}"
 
 # Create each SFTP user with home directory on the correct partition, and add to SFTP group.
 - name: SFTP-Server | Create sftp users

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
     name: "{{ item.name }}"
     groups: "{{ item.groups | default(omit) }}"
     append: "{{ item.append | default(False) }}"
-    home: "{{ item.home }}"
+    home: "{{ item.home | default(sftp_home_partition + '/' + item.name) }}"
     uid: "{{ item.uid | default(omit) }}"
     # `None` means default value -> default is to have a shell
     shell: "{{ None if (item.shell | default(True)) else sftp_nologin_shell }}"
@@ -58,7 +58,7 @@
 # A working chrooted SFTP setup requires root:sftgroup ownership of a user's home directory.
 - name: SFTP-Server | Correct ownership and permission of home directories
   file:
-    path: "{{ item.home }}"
+    path: "{{ item.home | default(sftp_home_partition + '/' + item.name) }}"
     owner: root
     group: "{{ sftp_chroot_group }}"
     mode: "0750"
@@ -81,12 +81,12 @@
     name: "{{ item.name }}"
     password: "{{ item.password }}"
   with_items: "{{ sftp_users }}"
-  when: "{{ item.update_password | default(False) }}"
+  when: item.update_password | default(False)
 
 # Create directories for all SFTP users. Optional, but recommended.
 - name: SFTP-Server | Create directories
   file:
-    path: "{{ item[0].home }}/{{ item[1].name | default(item[1]) }}"
+    path: "{{ item[0].home | default(sftp_home_partition + '/' + item[0].name) }}/{{ item[1].name | default(item[1]) }}"
     owner: "{{ item[1].owner | default(item[0].name) }}"
     group: "{{ item[1].group | default(item[0].name) }}"
     mode: "{{ item[1].mode | default(0750) }}"
@@ -98,7 +98,7 @@
 # Create directories for individual SFTP users. Optional.
 - name: SFTP-Server | Create directories per user
   file:
-    path: "{{ item[0].home }}/{{ item[1].name | default(item[1]) }}"
+    path: "{{ item[0].home | default(sftp_home_partition + '/' + item[0].name) }}/{{ item[1].name | default(item[1]) }}"
     owner: "{{ item[1].owner | default(item[0].name) }}"
     group: "{{ item[1].group | default(item[0].name) }}"
     mode: "{{ item[1].mode | default(0750) }}"
@@ -111,7 +111,7 @@
 
 - name: SFTP-Server | Create dev directory for logging
   file:
-    path: "{{ item.home }}/dev"
+    path: "{{ item.home | default(sftp_home_partition + '/' + item.name) }}/dev"
     owner: root
     group: root
     state: directory
@@ -126,7 +126,7 @@
     block: |
       # Create an additional socket for some of the sshd chrooted users.
       {% for user in sftp_users %}
-      $AddUnixListenSocket {{ user.home }}/dev/log
+      $AddUnixListenSocket {{ user.home | default(sftp_home_partition + '/' + user.name) }}/dev/log
       {% endfor %}
 
       # Log internal-sftp in a separate file
@@ -144,7 +144,7 @@
     dest: "/etc/ssh/ssh_host_{{ item.key }}_key.pub"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
     content: "{{ item.value }}"
   when: sftp_host_keys is defined
   with_dict: "{{ sftp_host_keys }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: SFTP-Server | Add 'Match User' sshd_config block
   blockinfile:
     dest: /etc/ssh/sshd_config
-    marker: '# {mark} SFTP-Server {{ item.name }} block'
+    marker: '# {mark} SFTP-Server {{ item.name }} user block'
     block: |
       Match User {{ item.name }}
           ForceCommand internal-sftp {{ sftp_enable_logging | ternary('-l VERBOSE', '') }} {% if item.login_directory is defined %}-d {{ item.login_directory }}{% endif %}{{''}}
@@ -31,7 +31,7 @@
 - name: SFTP-Server | Add 'Match Group' sshd_config block
   blockinfile:
     dest: /etc/ssh/sshd_config
-    marker: '# {mark} SFTP-Server {{ item.name }} block'
+    marker: '# {mark} SFTP-Server {{ item.name }} group block'
     block: |
       Match Group {{ item.name }}
           ChrootDirectory %h


### PR DESCRIPTION
Add possibility to log in to a subdirectory from home directory.

Example :

```yml
sftp_home_partition: /home
sftp_allow_passwords: True
sftp_enable_logging: True
sftp_enable_login_directory: True
sftp_groups:
- name: sftpusers
sftp_users:
- name: myuser
  password: "***"
  shell: False
  groups:
  - sftpusers
  login_directory: sftp
  sftp_directories:
  - sftp
  - other
```